### PR TITLE
chore: support `arm64` platform in Docker images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ file. This change log follows the conventions of
 
 Nothing here yet.
 
+### Added
+
+- Support `arm64` platform in Docker images
+  ([#111](https://github.com/pilosus/dienstplan/issues/111))
+
 ## [1.1.98] - 2023-10-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 ### Build stage ###
 ###################
 
-FROM clojure:temurin-21-tools-deps-alpine AS build
+FROM clojure:temurin-21-tools-deps-bookworm-slim AS build
 
 # Create a working directory
 RUN mkdir -p /usr/src/app

--- a/Dockerfile-test
+++ b/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM clojure:temurin-21-tools-deps-alpine
+FROM clojure:temurin-21-tools-deps-bookworm-slim
 RUN mkdir -p /usr/src/app
 COPY deps.edn /usr/src/app/
 WORKDIR /usr/src/app


### PR DESCRIPTION
Closed #111 