### PR TITLE
fix: add support for typographic quotes in schedules

### DIFF
--- a/src/dienstplan/commands.clj
+++ b/src/dienstplan/commands.clj
@@ -396,7 +396,8 @@ Caveats:
 (defn parse-args-schedule-cmd
   [command-parsed]
   (let [args (get-command-args command-parsed)
-        matcher (re-matcher regex-schedule args)
+        args' (string/replace args #"[\u201C\u201D\u00AB\u00BB\u201E\u201F\u2039\u203A\u275D\u275E]" "\"")
+        matcher (re-matcher regex-schedule args')
         result (when (.matches matcher)
                  {:subcommand (.group matcher "subcommand")
                   :executable (.group matcher "executable")

--- a/test/dienstplan/commands_test.clj
+++ b/test/dienstplan/commands_test.clj
@@ -123,6 +123,31 @@
      :executable "rotate my-rota"
      :crontab "9 0 * * Mon-Fri"}
     "Schedule create"]
+   ["<@U02HXENLLPN> schedule create \u201Crotate my-rota\u201D 9 0 * * Mon-Fri"
+    {:subcommand "create"
+     :executable "rotate my-rota"
+     :crontab "9 0 * * Mon-Fri"}
+    "Schedule create with typographic quotes i"]
+   ["<@U02HXENLLPN> schedule create \u00ABrotate my-rota\u00BB 9 0 * * Mon-Fri"
+    {:subcommand "create"
+     :executable "rotate my-rota"
+     :crontab "9 0 * * Mon-Fri"}
+    "Schedule create with typographic quotes ii"]
+   ["<@U02HXENLLPN> schedule create \u201Erotate my-rota\u201F 9 0 * * Mon-Fri"
+    {:subcommand "create"
+     :executable "rotate my-rota"
+     :crontab "9 0 * * Mon-Fri"}
+    "Schedule create with typographic quotes iii"]
+   ["<@U02HXENLLPN> schedule create \u2039rotate my-rota\u203A 9 0 * * Mon-Fri"
+    {:subcommand "create"
+     :executable "rotate my-rota"
+     :crontab "9 0 * * Mon-Fri"}
+    "Schedule create with typographic quotes iv"]
+   ["<@U02HXENLLPN> schedule create \u275Drotate my-rota\u275E 9 0 * * Mon-Fri"
+    {:subcommand "create"
+     :executable "rotate my-rota"
+     :crontab "9 0 * * Mon-Fri"}
+    "Schedule create with typographic quotes v"]
    ["<@U02HXENLLPN> schedule delete \"rotate my-rota\""
     {:subcommand "delete"
      :executable "rotate my-rota"


### PR DESCRIPTION
An attempt to fix #119 

1. Added a regular expression to match and replace following characters used as double quotes in different languages:

- “ (Left Double Quotation Mark): `\u201C`
- ” (Right Double Quotation Mark): `\u201D`
- « (Left-Pointing Double Angle Quotation Mark): `\u00AB`
- » (Right-Pointing Double Angle Quotation Mark): `\u00BB`
- „ (Double Low-9 Quotation Mark): `\u201E`
- ‟ (Double Reversed Prime Quotation Mark): `\u201F`
- ‹ (Single Left-Pointing Angle Quotation Mark): `\u2039`
- › (Single Right-Pointing Angle Quotation Mark): `\u203A`
- ❝ (Heavy Double Turned Comma Quotation Mark Ornament): `\u275D`
- ❞ (Heavy Double Comma Quotation Mark Ornament): `\u275E`

2. Added schedule parsing test cases