### PR TITLE
tech: bump dependencies

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,17 +22,17 @@ jobs:
       id-token: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata (tags/labels)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_USERNAME }}/dienstplan
           tags: |
@@ -40,7 +40,7 @@ jobs:
             type=ref,event=tag
 
       - name: Build (and push on main/tags)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: "21"
 
       - name: Setup Clojure CLI
-        uses: DeLaGuardo/setup-clojure@13.4
+        uses: DeLaGuardo/setup-clojure@13.6.0
         with:
           cli: "latest"
 

--- a/deps.edn
+++ b/deps.edn
@@ -6,25 +6,25 @@
  :deps
  { ;; Clojure
   org.clojure/clojure {:mvn/version "1.12.4"}
-  org.clojure/tools.cli {:mvn/version "1.2.245"}
+  org.clojure/tools.cli {:mvn/version "1.4.256"}
 
   ;; Web framework
-  ring/ring-core {:mvn/version "1.15.3"}
-  ring/ring-jetty-adapter {:mvn/version "1.15.3"}
+  ring/ring-core {:mvn/version "1.15.4"}
+  ring/ring-jetty-adapter {:mvn/version "1.15.4"}
   ring/ring-json {:mvn/version "0.5.1"}
 
   ;; Routing
   bidi/bidi {:mvn/version "2.1.6"}
 
   ;; Logging
-  org.clojure/tools.logging {:mvn/version "1.3.0"}
-  ch.qos.logback/logback-classic {:mvn/version "1.5.22"}
+  org.clojure/tools.logging {:mvn/version "1.3.1"}
+  ch.qos.logback/logback-classic {:mvn/version "1.5.32"}
   ch.qos.logback.contrib/logback-json-classic {:mvn/version "0.1.5"}
   ch.qos.logback.contrib/logback-jackson {:mvn/version "0.1.5"}
-  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.20.1"}
+  com.fasterxml.jackson.core/jackson-databind {:mvn/version "2.21.3"}
 
   ;; Alerts
-  io.sentry/sentry-clj {:mvn/version "8.25.237"}
+  io.sentry/sentry-clj {:mvn/version "8.34.247"}
 
   ;; Validation
   expound/expound {:mvn/version "0.9.0"}
@@ -37,17 +37,17 @@
   clj-http/clj-http {:mvn/version "3.13.1"}
 
   ;; JSON parsing
-  cheshire/cheshire {:mvn/version "6.1.0"}
+  cheshire/cheshire {:mvn/version "6.2.0"}
 
   ;; DB
-  com.github.seancorfield/next.jdbc {:mvn/version "1.3.1086"}
-  org.postgresql/postgresql {:mvn/version "42.7.8"}
+  com.github.seancorfield/next.jdbc {:mvn/version "1.3.1093"}
+  org.postgresql/postgresql {:mvn/version "42.7.11"}
   com.zaxxer/HikariCP {:mvn/version "7.0.2"}
   dev.weavejester/ragtime {:mvn/version "0.12.1"}
-  com.github.seancorfield/honeysql {:mvn/version "2.7.1364"}
+  com.github.seancorfield/honeysql {:mvn/version "2.7.1368"}
 
   ;; Cron
-  org.pilosus/kairos {:mvn/version "0.2.45"}
+  org.pilosus/kairos {:mvn/version "0.2.66"}
 
   ;; Cryptography
   buddy/buddy-core {:mvn/version "1.12.0-430"}}
@@ -56,7 +56,7 @@
   ;; Building
   ;; clojure -T:build (clean|jar|uberjar)
   :build
-  {:replace-deps {io.github.clojure/tools.build {:git/tag "v0.10.11" :git/sha "c6c670a"}}
+  {:replace-deps {io.github.clojure/tools.build {:git/tag "v0.10.13" :git/sha "ae52edf"}}
    :ns-default build}
 
   ;; Running
@@ -81,12 +81,12 @@
    {io.github.athos/clj-check {:git/tag "0.1.0" :git/sha "0ca84df"}
     cloverage/cloverage {:mvn/version "1.2.4"}
     jonase/eastwood {:mvn/version "1.4.3"}
-    io.github.weavejester/cljfmt {:git/tag "0.15.6" :git/sha "5498e22"}
+    io.github.weavejester/cljfmt {:git/tag "0.16.4" :git/sha "389e7ca"}
     io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}
-    nrepl/nrepl {:mvn/version "1.5.1"}
-    cider/cider-nrepl {:mvn/version "0.58.0"}
-    com.bhauman/rebel-readline {:mvn/version "0.1.5"}
-    org.clojure/test.check {:mvn/version "1.1.2"}}}
+    nrepl/nrepl {:mvn/version "1.7.0"}
+    cider/cider-nrepl {:mvn/version "0.59.0"}
+    com.bhauman/rebel-readline {:mvn/version "0.1.7"}
+    org.clojure/test.check {:mvn/version "1.1.3"}}}
 
   ;; REPL
   ;; clojure -M:dev:repl
@@ -189,7 +189,7 @@
   ;; https://github.com/clj-holmes/clj-watson
   :watson
   {:replace-paths ["."]
-   :replace-deps {io.github.clj-holmes/clj-watson {:git/tag "v6.0.1" :git/sha "b520351"}}
+   :replace-deps {io.github.clj-holmes/clj-watson {:git/tag "v6.1.0" :git/sha "be98e4d"}}
    :main-opts ["-m" "clj-watson.cli" "scan"]
    :exec-fn clj-watson.entrypoint/scan
    :exec-args {:output "stdout"

--- a/test/dienstplan/api_test.clj
+++ b/test/dienstplan/api_test.clj
@@ -706,7 +706,7 @@
       (is (= 200 (:status schedule-create-rotate-response)))
       (is (=
            {:channel "C123"
-            :text "Executable `rotate my-rota` successfully scheduled with `5 0 * * Mon-Fri` (at minute 5, past hour 0, on every day of week from Monday through Friday, in every month)"}
+            :text "Executable `rotate my-rota` successfully scheduled with `5 0 * * Mon-Fri` (every weekday at 0:05)"}
            (-> schedule-create-rotate-response
                :body
                (json/parse-string true))))
@@ -724,7 +724,7 @@
       (is (= 200 (:status schedule-create-who-response)))
       (is (=
            {:channel "C123"
-            :text "Executable `who my-rota` successfully scheduled with `0 9 * * Mon-Fri` (at minute 0, past hour 9, on every day of week from Monday through Friday, in every month)"}
+            :text "Executable `who my-rota` successfully scheduled with `0 9 * * Mon-Fri` (every weekday at 9:00)"}
            (-> schedule-create-who-response
                :body
                (json/parse-string true))))
@@ -776,13 +776,13 @@
 
 (def params-test-schedule-explain
   [["0 22 * * *"
-    "Crontab `0 22 * * *` means the executable will be run at minute 0, past hour 22, on every day, in every month"
+    "Crontab `0 22 * * *` means the executable will be run every day at 22:00"
     "ok"]
    ["67 22 * * *"
     (format "`schedule` command failed: `<crontab>` error: Value error in 'minute' field. Given value: [67, 68). Expected: [0, 60)\n\n%s" cmd/help-cmd-schedule)
     "Wrong value"]
    ["Mon-Fri"
-    (format "`schedule` command failed: `<crontab>` error: Invalid crontab format\n\n%s" cmd/help-cmd-schedule)
+    (format "`schedule` command failed: `<crontab>` error: Invalid cron entry format\n\n%s" cmd/help-cmd-schedule)
     "Parding error"]])
 
 (deftest ^:integration test-schedule-explain
@@ -893,7 +893,7 @@
     {:ok? false :error "`<executable>` cannot be parsed"}
     "Invalid executable, double quotes omitted"]
    ["<@u001> schedule create \"who my rota\" Mon-Fri"
-    {:ok? false :error "`<crontab>` error: Invalid crontab format"}
+    {:ok? false :error "`<crontab>` error: Invalid cron entry format"}
     "Invalid crontab"]])
 
 (deftest ^:integration test-schedule-command-invalid-args
@@ -921,7 +921,7 @@
   (testing "Duplicate schedule"
     (let [executable "rotate my-rota"
           crontab "0 9 * * Mon-Fri"
-          explain "at minute 0, past hour 9, on every day of week from Monday through Friday, in every month"
+          explain "every weekday at 9:00"
           command (format "<@U001> schedule create \"%s\" %s"
                           executable
                           crontab)


### PR DESCRIPTION
Changed:

- after migration to `kairos v0.2.66` shorter cron explanations are used