### PR TITLE
tech: bump postgres version for docker compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,8 @@ jobs:
       - name: Run tests
         run: make TEST_ARGS=":codecov? true" cloverage
       - name: Update code coverage report
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        run: |
-          curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
-          curl -Os https://uploader.codecov.io/latest/linux/codecov
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod +x codecov
-          ./codecov -t ${CODECOV_TOKEN} -f target/coverage/codecov.json
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: target/coverage/codecov.json
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests
         run: make TEST_ARGS=":codecov? true" cloverage
       - name: Update code coverage report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: target/coverage/codecov.json

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:16.2-alpine3.19
+    image: postgres:18-alpine
     ports:
       - "15432:5432"
     volumes:

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@ services:
     ports:
       - "15432:5432"
     volumes:
-      - "/tmp/diestplan-db-data:/var/lib/postgresql/data"
+      - "/tmp/dienstplan-db-data:/var/lib/postgresql"
     env_file:
       - .env
 


### PR DESCRIPTION
Let's bump postgres to the latest 18.4 version for docker compose to test if it will work with the most recent PG version